### PR TITLE
Home redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mqtt5-explorer",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": false,
   "license": "GPLv3",
   "description": "A simple MQTT client that supports MQTT5 protocol.",

--- a/src/background.js
+++ b/src/background.js
@@ -118,12 +118,12 @@ let menuTemplate = (page = pages.HOME) => [
         role: "copy",
       },
       {
-        label: "Paste",
-        role: "paste",
-      },
-      {
         label: "Cut",
         role: "cut",
+      },
+      {
+        label: "Paste",
+        role: "paste",
       },
       ...(page === pages.HOME && !isMac
         ? [
@@ -141,11 +141,13 @@ let menuTemplate = (page = pages.HOME) => [
             },
           ]
         : []),
-      ...(page === pages.VIEWER
-        ? [
-            {
-              type: "separator",
-            },
+    ],
+  },
+  ...(page === pages.VIEWER
+    ? [
+        {
+          label: "Tools",
+          submenu: [
             {
               label: "Toggle search",
               accelerator: "CommandOrControl+F",
@@ -155,10 +157,19 @@ let menuTemplate = (page = pages.HOME) => [
                 }
               },
             },
-          ]
-        : []),
-    ],
-  },
+            {
+              label: "Toggle logging",
+              accelerator: "CommandOrControl+Shift+N",
+              click: () => {
+                if (win != undefined && win.webContents != undefined) {
+                  win.webContents.send("notificationPressed");
+                }
+              },
+            },
+          ],
+        },
+      ]
+    : []),
   ...(!isMac
     ? [
         {

--- a/src/components/ConnectionForm.vue
+++ b/src/components/ConnectionForm.vue
@@ -1,65 +1,156 @@
 <template>
-  <v-form>
-    <div class="input-container">
-      <div row>
-        <v-text-field
-          v-model="connectionData.name"
-          v-bind:outlined="outline"
-          v-bind:rules="staticConnectionProperties.rules.name"
-          label="Name"
-          required
-        />
-        <v-select
-          v-model="connectionData.version"
-          v-bind:items="versions"
-          v-bind:outlined="outline"
-          label="Version"
-          style="max-width: 12ch"
-        />
+  <v-card class="conn-form-card" flat>
+    <v-card-text style="overflow: hidden; position: relative">
+      <div class="pa-4" style="overflow: auto; position: absolute; inset: 0">
+        <div row>
+          <v-text-field
+            v-model="connectionData.name"
+            v-bind:outlined="outline"
+            v-bind:rules="staticConnectionProperties.rules.name"
+            label="Name"
+            required
+          />
+          <v-select
+            v-model="connectionData.version"
+            v-bind:items="versions"
+            v-bind:outlined="outline"
+            label="Version"
+            style="max-width: 12ch"
+          />
+        </div>
+        <div row>
+          <v-select
+            v-model="connectionData.protocol"
+            v-bind:items="protocols"
+            v-bind:outlined="outline"
+            v-bind:rules="staticConnectionProperties.rules.protocol"
+            label="Protocol"
+            style="max-width: 15ch"
+            required
+          />
+          <v-text-field
+            v-model="connectionData.host"
+            v-bind:outlined="outline"
+            v-bind:rules="staticConnectionProperties.rules.host"
+            label="Host"
+            required
+          />
+          <v-text-field
+            v-model="connectionData.port"
+            v-bind:outlined="outline"
+            v-bind:rules="staticConnectionProperties.rules.port"
+            label="Port"
+            style="max-width: 12ch"
+            required
+          />
+        </div>
+        <div row>
+          <v-text-field
+            v-model="connectionData.username"
+            v-bind:outlined="outline"
+            label="Username"
+          />
+          <v-text-field
+            v-model="connectionData.password"
+            v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+            v-bind:outlined="outline"
+            v-bind:type="showPassword ? 'text' : 'password'"
+            v-on:click:append="showPassword = !showPassword"
+            label="Password"
+          />
+        </div>
+
+        <v-expansion-panels style="border: 1px solid grey" class="mt-6" flat>
+          <v-expansion-panel>
+            <v-expansion-panel-header>
+              <div>
+                <v-icon small>mdi-tune-variant</v-icon>
+                <span class="ms-4">Advanced connection settings</span>
+              </div>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <div row>
+                <v-switch
+                  v-model="connectionData.validateCertificate"
+                  label="Validate Certificate"
+                  inset
+                />
+                <v-spacer />
+                <div
+                  v-on:click="selectFile('caCert')"
+                  v-bind:title="connectionData.caCert"
+                  class="d-flex align-center cert-selector"
+                >
+                  <v-text-field
+                    v-model="connectionData.caCert"
+                    label="CA cert file"
+                    class="cert-selector"
+                    readonly
+                  />
+                  <v-btn v-on:click.stop="deselectFile('caCert')" icon>
+                    <v-icon>mdi-close</v-icon>
+                  </v-btn>
+                </div>
+              </div>
+              <div row>
+                <div
+                  v-on:click="selectFile('clientCert')"
+                  v-bind:title="connectionData.clientCert"
+                  class="d-flex align-center cert-selector"
+                >
+                  <v-text-field
+                    v-model="connectionData.clientCert"
+                    label="Client cert file"
+                    class="cert-selector"
+                    readonly
+                  />
+                  <v-btn v-on:click.stop="deselectFile('clientCert')" icon>
+                    <v-icon>mdi-close</v-icon>
+                  </v-btn>
+                </div>
+                <div
+                  v-on:click="selectFile('clientKey')"
+                  v-bind:title="connectionData.clientKey"
+                  class="d-flex align-center cert-selector"
+                >
+                  <v-text-field
+                    v-model="connectionData.clientKey"
+                    label="Client key file"
+                    class="cert-selector"
+                    readonly
+                  />
+                  <v-btn v-on:click.stop="deselectFile('clientKey')" icon>
+                    <v-icon>mdi-close</v-icon>
+                  </v-btn>
+                </div>
+              </div>
+              <v-divider class="mb-2" />
+              <div row>
+                <v-combobox
+                  v-model="connectionData.topics"
+                  v-bind:outlined="outline"
+                  append-icon=""
+                  label="Subscriptions"
+                  multiple
+                >
+                  <template v-slot:selection="{ item, index }">
+                    <v-chip
+                      v-on:click:close="connectionData.topics.splice(index, 1)"
+                      class="my-3"
+                      close
+                    >
+                      <span class="me-2 font-weight-bold">{{ item }}</span>
+                    </v-chip>
+                  </template>
+                </v-combobox>
+              </div>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
       </div>
-      <div row>
-        <v-select
-          v-model="connectionData.protocol"
-          v-bind:items="protocols"
-          v-bind:outlined="outline"
-          v-bind:rules="staticConnectionProperties.rules.protocol"
-          label="Protocol"
-          style="max-width: 15ch"
-          required
-        />
-        <v-text-field
-          v-model="connectionData.host"
-          v-bind:outlined="outline"
-          v-bind:rules="staticConnectionProperties.rules.host"
-          label="Host"
-          required
-        />
-        <v-text-field
-          v-model="connectionData.port"
-          v-bind:outlined="outline"
-          v-bind:rules="staticConnectionProperties.rules.port"
-          label="Port"
-          style="max-width: 12ch"
-          required
-        />
-      </div>
-      <div row>
-        <v-text-field
-          v-model="connectionData.username"
-          v-bind:outlined="outline"
-          label="Username"
-        />
-        <v-text-field
-          v-model="connectionData.password"
-          v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-          v-bind:outlined="outline"
-          v-bind:type="showPassword ? 'text' : 'password'"
-          v-on:click:append="showPassword = !showPassword"
-          label="Password"
-        />
-      </div>
-    </div>
-    <div class="mt-4" foot>
+    </v-card-text>
+
+    <v-card-actions>
       <v-btn v-on:click="deleteConnection" color="error" text>Delete</v-btn>
       <v-btn
         v-bind:disabled="!validConnectionData"
@@ -68,22 +159,7 @@
       >
         Save
       </v-btn>
-      <div />
-      <v-tooltip bottom>
-        <template v-slot:activator="{ on, attrs }">
-          <v-btn
-            v-bind="attrs"
-            v-on:click="settingsDialog = true"
-            v-on="on"
-            fab
-            icon
-            small
-          >
-            <v-icon>mdi-tune-variant</v-icon>
-          </v-btn>
-        </template>
-        <span>Advanced settings</span>
-      </v-tooltip>
+      <v-spacer />
       <v-btn
         v-bind:disabled="!validConnectionData"
         v-on:click="connectToMqtt"
@@ -92,107 +168,16 @@
       >
         Connect
       </v-btn>
-    </div>
-
-    <v-dialog v-model="settingsDialog" max-width="75ch" persistent scrollable>
-      <v-card>
-        <v-toolbar color="primary" dark flat text>
-          <v-toolbar-title>Advanced connection settings</v-toolbar-title>
-        </v-toolbar>
-
-        <v-card-text class="dialog-text-container pt-4">
-          <div row>
-            <v-switch
-              v-model="connectionData.validateCertificate"
-              label="Validate Certificate"
-              inset
-            />
-          </div>
-          <div row>
-            <div v-on:click="selectFile('caCert')" class="d-flex align-center">
-              <v-text-field
-                v-model="connectionData.caCert"
-                label="CA cert file"
-                disabled
-              />
-              <v-btn v-on:click.stop="deselectFile('caCert')" icon>
-                <v-icon>mdi-close</v-icon>
-              </v-btn>
-            </div>
-            <div
-              v-on:click="selectFile('clientCert')"
-              class="d-flex align-center"
-            >
-              <v-text-field
-                v-model="connectionData.clientCert"
-                label="Client cert file"
-                disabled
-              />
-              <v-btn v-on:click.stop="deselectFile('clientCert')" icon>
-                <v-icon>mdi-close</v-icon>
-              </v-btn>
-            </div>
-            <div
-              v-on:click="selectFile('clientKey')"
-              class="d-flex align-center"
-            >
-              <v-text-field
-                v-model="connectionData.clientKey"
-                label="Client key file"
-                disabled
-              />
-              <v-btn v-on:click.stop="deselectFile('clientKey')" icon>
-                <v-icon>mdi-close</v-icon>
-              </v-btn>
-            </div>
-          </div>
-          <v-divider class="mb-2" />
-          <div row>
-            <v-combobox
-              v-model="connectionData.topics"
-              v-bind:outlined="outline"
-              append-icon=""
-              label="Subscriptions"
-              multiple
-            >
-              <template v-slot:selection="{ item, index }">
-                <v-chip
-                  v-on:click:close="connectionData.topics.splice(index, 1)"
-                  class="my-3"
-                  close
-                >
-                  <span class="me-2 font-weight-bold">{{ item }}</span>
-                </v-chip>
-              </template>
-            </v-combobox>
-          </div>
-        </v-card-text>
-
-        <v-card-actions>
-          <v-spacer />
-          <v-btn v-on:click="settingsDialog = false" text> Done </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </v-form>
+    </v-card-actions>
+  </v-card>
 </template>
 
 <style scoped>
-.input-container {
-  display: flex;
-  flex-direction: column;
-}
-
-.small-input {
-  max-width: 10ch;
-}
-
-.dialog-width {
-  width: 10ch !important;
-}
-
-.dialog-text-container {
-  max-height: 40ch;
+.conn-form-card {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr min-content;
 }
 
 div[row] {
@@ -201,9 +186,12 @@ div[row] {
   gap: 1.5em;
 }
 
-div[foot] {
-  display: grid;
-  grid-template-columns: min-content min-content 1fr min-content min-content;
+div[row] > * {
+  flex-grow: 1;
+}
+
+.cert-selector {
+  cursor: pointer;
 }
 </style>
 
@@ -225,7 +213,6 @@ export default {
       { text: "3.1.1", value: 4 },
       { text: "5.0", value: 5 },
     ],
-    settingsDialog: false,
     showPassword: false,
     staticConnectionProperties: ConnectionProperties,
   }),

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,37 @@
 <template>
-  <v-container class="connection-container">
+  <div class="connection-container">
+    <v-app-bar flat>
+      <div v-on:click="scrollTabs('top')" class="title" style="cursor: pointer">
+        MQTT Connections
+      </div>
+      <v-spacer />
+      <v-text-field
+        v-model="searchConnection"
+        label="Search connections"
+        clearable
+        dense
+        hide-details
+        outlined
+      />
+      <v-spacer />
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            v-on:click="addTmpConnection"
+            v-on="on"
+            class="me-2"
+            color="primary"
+            fab
+            small
+          >
+            <v-icon>mdi-plus</v-icon>
+          </v-btn>
+        </template>
+        <span>New connection</span>
+      </v-tooltip>
+    </v-app-bar>
+
     <v-navigation-drawer
       v-model="settingsDrawer"
       width="62ch"
@@ -180,93 +212,62 @@
       </template>
     </v-navigation-drawer>
 
-    <div class="caption client-id grey--text pa-2">
-      <span>Client ID:</span>
-      <span class="primary--text font-weight-bold">{{ clientId }}</span>
-    </div>
-
-    <div class="caption version-number grey--text pa-2">
-      <div class="d-flex align-center">
-        <v-img class="me-2" src="../assets/logo.svg" style="max-width: 1.5em" />
-        v{{ version }}
-      </div>
-    </div>
-
-    <v-card class="card-width">
-      <v-toolbar color="primary" dark flat text>
-        <v-toolbar-title>MQTT Connections</v-toolbar-title>
-        <v-spacer />
-        <div class="d-flex align-center">
-          <v-text-field
-            v-model="searchConnection"
-            class="pe-4"
-            label="Search connections"
-            color="white"
-            clearable
-            dense
-            hide-details
-            outlined
-          />
-          <v-tooltip bottom>
-            <template v-slot:activator="{ on, attrs }">
-              <v-btn
-                v-bind="attrs"
-                v-on:click="addTmpConnection"
-                v-on="on"
-                class="me-2"
-                fab
-                light
-                small
-              >
-                <v-icon color="primary">mdi-plus</v-icon>
-              </v-btn>
-            </template>
-            <span>New connection</span>
-          </v-tooltip>
-        </div>
-      </v-toolbar>
-
-      <div v-bind:class="'tab-no-overflow-' + outline" row>
-        <div class="tab-scroll pe-5">
-          <v-tabs v-model="tabId" class="tab-width" vertical>
-            <v-tab
-              v-for="(connection, i) in connectionsAvailable"
-              v-show="filteredConnectionIDs.includes(connection.id)"
-              v-bind:key="'tab-' + i"
-            >
-              <div
-                v-bind:class="{
-                  'tab-truncate': true,
-                  'tab-width': true,
-                  'text-left': true,
-                  'primary--text': tabId === i,
-                  'text--lighten-2': darkTheme,
-                }"
-              >
-                {{ connection.name }}
-              </div>
-            </v-tab>
-          </v-tabs>
-        </div>
-
-        <v-tabs-items v-model="tabId" class="tab-items-container">
-          <v-tab-item
+    <div class="ma-2 connection-area">
+      <v-card id="tabs-list" class="conn-tabs-container" flat>
+        <v-tabs v-model="tabId" vertical>
+          <v-tab
             v-for="(connection, i) in connectionsAvailable"
-            v-bind:key="'connection-' + connection.id"
+            v-show="filteredConnectionIDs.includes(connection.id)"
+            v-bind:key="'tab-' + i"
+            v-bind:class="{
+              'tabs-left': filteredConnectionIDs.includes(connection.id),
+            }"
           >
-            <v-card-text>
-              <!-- Input form -->
-              <ConnectionForm
-                v-bind:properties="connection"
-                v-on:connect="connect($event, i)"
-                v-on:delete="confirmDelete(i)"
-                v-on:updated="dataChanged($event, i)"
-              />
-            </v-card-text>
-          </v-tab-item>
-        </v-tabs-items>
+            <div
+              v-bind:class="{
+                'tab-truncate': true,
+                'primary--text': tabId === i,
+                'text--lighten-2': darkTheme,
+              }"
+            >
+              {{ connection.name }}
+            </div>
+          </v-tab>
+        </v-tabs>
+      </v-card>
+      <v-tabs-items v-model="tabId" class="tab-items-container">
+        <v-tab-item
+          v-for="(connection, i) in connectionsAvailable"
+          v-bind:key="'connection-' + connection.id"
+          class="tab-items-container"
+        >
+          <ConnectionForm
+            v-bind:properties="connection"
+            v-on:connect="connect($event, i)"
+            v-on:delete="confirmDelete(i)"
+            v-on:updated="dataChanged($event, i)"
+          />
+        </v-tab-item>
+      </v-tabs-items>
+    </div>
+
+    <div class="foot-bar">
+      <div class="caption client-id grey--text pa-2">
+        <span>Client ID:</span>
+        <span class="primary--text font-weight-bold">{{ clientId }}</span>
       </div>
-    </v-card>
+
+      <div class="caption grey--text pa-2">
+        <div class="d-flex align-center">
+          <v-img
+            class="me-2"
+            src="../assets/logo.svg"
+            style="max-width: 1.5em"
+          />
+          v{{ version }}
+        </div>
+      </div>
+    </div>
 
     <!-- Connection deletion confirmation -->
     <v-dialog
@@ -307,51 +308,38 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-  </v-container>
+  </div>
 </template>
 
 <style scoped>
 .connection-container {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: min-content 1fr min-content;
 }
 
-div[row] {
-  display: flex;
-  flex-direction: row;
-  gap: 1.5em;
+.connection-area {
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  grid-template-rows: 1fr;
+  gap: 1em;
 }
 
-.card-width {
-  width: 94ch;
-}
-
-.tab-width {
-  width: 30ch;
+.conn-tabs-container {
+  overflow: auto;
 }
 
 .tab-items-container {
   width: 100%;
+  height: 100%;
+  background: transparent !important;
 }
 
-.tab-no-overflow-false {
-  min-height: 33ch !important;
-  max-height: 40ch !important;
-  overflow: hidden !important;
-}
-
-.tab-no-overflow-true {
-  min-height: 38ch !important;
-  max-height: 42ch !important;
-  overflow: hidden !important;
-}
-
-.tab-scroll {
-  overflow: auto !important;
-  overflow-x: hidden !important;
+.tabs-left {
+  display: flex;
+  justify-content: left;
 }
 
 .tab-truncate {
@@ -360,16 +348,13 @@ div[row] {
   text-overflow: ellipsis;
 }
 
-.version-number {
-  position: absolute;
-  bottom: 0;
-  right: 0;
+.foot-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .client-id {
-  position: absolute;
-  bottom: 0;
-  left: 0;
   display: flex;
   gap: 0.5em;
   align-items: center;
@@ -510,12 +495,22 @@ export default {
   },
 
   methods: {
+    scrollTabs(to = "bottom") {
+      this.$nextTick(() => {
+        const tabs = document.querySelector("#tabs-list");
+        const direction = to === "bottom" ? tabs.scrollHeight : 0;
+
+        tabs.scroll({ top: direction, behavior: "smooth" });
+      });
+    },
     toggleSettingsDrawer() {
       this.settingsDrawer = !this.settingsDrawer;
     },
     addTmpConnection() {
       this.$store.commit("addNewConnection", new ConnectionProperties());
+      this.searchConnection = undefined;
       this.tabId = this.connectionsAvailable.length - 1;
+      this.scrollTabs("bottom");
     },
     dataChanged(data, index) {
       data.saved = true;
@@ -533,6 +528,7 @@ export default {
         callback: () => {
           this.persistConnections();
           this.tabId = 0;
+          this.scrollTabs("top");
         },
       });
     },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -157,6 +157,12 @@
               {{ isMacOs ? "Cmd" : "Ctrl" }} + F
             </v-list-item-action-text>
           </v-list-item>
+          <v-list-item link>
+            <v-list-item-content>Notifications and logging</v-list-item-content>
+            <v-list-item-action-text>
+              {{ isMacOs ? "Cmd" : "Ctrl" }} + Shift + N
+            </v-list-item-action-text>
+          </v-list-item>
         </v-list>
       </v-list>
 
@@ -188,24 +194,36 @@
 
     <v-card class="card-width">
       <v-toolbar color="primary" dark flat text>
-        <v-toolbar-title>MQTT Connection</v-toolbar-title>
+        <v-toolbar-title>MQTT Connections</v-toolbar-title>
         <v-spacer />
-        <v-tooltip bottom>
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn
-              v-bind="attrs"
-              v-on:click="addTmpConnection"
-              v-on="on"
-              class="me-2"
-              fab
-              light
-              small
-            >
-              <v-icon color="primary">mdi-plus</v-icon>
-            </v-btn>
-          </template>
-          <span>New connection</span>
-        </v-tooltip>
+        <div class="d-flex align-center">
+          <v-text-field
+            v-model="searchConnection"
+            class="pe-4"
+            label="Search connections"
+            color="white"
+            clearable
+            dense
+            hide-details
+            outlined
+          />
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                v-bind="attrs"
+                v-on:click="addTmpConnection"
+                v-on="on"
+                class="me-2"
+                fab
+                light
+                small
+              >
+                <v-icon color="primary">mdi-plus</v-icon>
+              </v-btn>
+            </template>
+            <span>New connection</span>
+          </v-tooltip>
+        </div>
       </v-toolbar>
 
       <div v-bind:class="'tab-no-overflow-' + outline" row>
@@ -213,6 +231,7 @@
           <v-tabs v-model="tabId" class="tab-width" vertical>
             <v-tab
               v-for="(connection, i) in connectionsAvailable"
+              v-show="filteredConnectionIDs.includes(connection.id)"
               v-bind:key="'tab-' + i"
             >
               <div
@@ -372,6 +391,7 @@ export default {
     deleteIndex: -1,
     settingsDrawer: false,
     deleteDialog: false,
+    searchConnection: undefined,
     colors: [
       { text: "Punchy Pink", value: { light: "#E91E63", dark: "#EC407A" } },
       { text: "Hipster Purple", value: { light: "#9C27B0", dark: "#AB47BC" } },
@@ -392,6 +412,15 @@ export default {
   computed: {
     version() {
       return process.env.VUE_APP_VERSION;
+    },
+    filteredConnectionIDs() {
+      return this.connectionsAvailable
+        .filter(
+          (c) =>
+            !this.searchConnection ||
+            c.name.toLowerCase().includes(this.searchConnection.toLowerCase())
+        )
+        .map((c) => c.id);
     },
     selectedTheme: {
       get() {

--- a/src/views/MqttViewer.vue
+++ b/src/views/MqttViewer.vue
@@ -116,21 +116,6 @@
         </v-text-field>
       </v-slide-y-transition>
       <v-spacer />
-      <div>
-        <v-tooltip bottom>
-          <template v-slot:activator="{ on, attrs }">
-            <v-btn
-              v-bind="attrs"
-              v-on:click="notifySettings = true"
-              v-on="on"
-              icon
-            >
-              <v-icon>mdi-message-badge-outline</v-icon>
-            </v-btn>
-          </template>
-          <span>Notifications and logging</span>
-        </v-tooltip>
-      </div>
       <div v-if="selectedId !== -1" center-vertical class="ms-2">
         <v-tooltip bottom>
           <template v-slot:activator="{ on, attrs }">
@@ -889,6 +874,7 @@ export default {
 
     ipcRenderer.send("enterViewerPage");
     ipcRenderer.on("searchPressed", this.toggleSearchField);
+    ipcRenderer.on("notificationPressed", this.toggleNotificationsDialog);
   },
 
   mounted() {
@@ -902,6 +888,11 @@ export default {
   beforeDestroy() {
     this.messageLogger?.stopLogging();
     ipcRenderer.removeListener("searchPressed", this.toggleSearchField);
+    // eslint-disable-next-line prettier/prettier
+    ipcRenderer.removeListener(
+      "notificationPressed",
+      this.toggleNotificationsDialog
+    );
   },
 
   methods: {
@@ -914,6 +905,9 @@ export default {
         if (!this.searchTreeVisible) this.searchTerm = undefined;
         else this.$refs.searchField.focus();
       });
+    },
+    toggleNotificationsDialog() {
+      this.notifySettings = !this.notifySettings;
     },
     disconnectFromMqtt(msg = undefined) {
       this.$connection.disconnect(() => {

--- a/src/views/MqttViewer.vue
+++ b/src/views/MqttViewer.vue
@@ -134,7 +134,7 @@
       </div>
     </v-app-bar>
 
-    <div class="mx-4 my-2 explorer-grid-container">
+    <div class="ma-2 explorer-grid-container">
       <v-card class="treeview-container" flat>
         <v-treeview
           v-bind:filter="filterTree"
@@ -417,9 +417,20 @@
               </v-card>
             </v-expansion-panel-content>
             <v-expansion-panel-content v-else>
-              <v-btn v-on:click="newForPublishing()" block>
-                <v-icon>mdi-plus</v-icon>
-              </v-btn>
+              <v-tooltip bottom>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-btn
+                    v-bind="attrs"
+                    v-on:click="newForPublishing()"
+                    v-on="on"
+                    color="primary"
+                    block
+                  >
+                    <v-icon>mdi-plus</v-icon>
+                  </v-btn>
+                </template>
+                <span>Create a new topic</span>
+              </v-tooltip>
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>


### PR DESCRIPTION
- Removed the *Notifications and logging* button from the MQTT viewer and moved it to the app menu
- Added the *Tools* button in the app menu for aggregating the search and the logging functionalities
- Added new shortcut for accessing the *Notifications and logging* dialog: `Ctrl + Shift + N`
- Redesigned the home screen (*Connections* section) to be more usable and modern